### PR TITLE
Feat/better intake tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,7 @@
       "type": "wpilib",
       "name": "WPILib roboRIO Debug",
       "request": "launch",
-      "desktop": false,
+      "desktop": true,
     }
   ]
 }

--- a/src/main/cpp/subsystems/Intake.cpp
+++ b/src/main/cpp/subsystems/Intake.cpp
@@ -85,6 +85,22 @@ bool Intake::SetExtended(const bool &extended) {
     return true;
 }
 
+/**
+ * A method to get the 'direction' variable of the intake subsystem
+ * This should only be used to verify proper functioning of the intake subsystem
+ */
+int Intake::GetDirection() {
+    return direction;
+}
+
+/**
+ * A method to get the setpoint of the intake position PID controller
+ * Mainly for unit tests right now
+ */
+double Intake::GetSetpoint() {
+    return intake_pid.GetSetpoint();
+}
+
 // this method seems useful but we don't end up using it in the Java version so it might get cut
 // leaving here (untouched except for commented out) for now
 /**

--- a/src/main/cpp/subsystems/Intake.cpp
+++ b/src/main/cpp/subsystems/Intake.cpp
@@ -2,6 +2,8 @@
 #include "subsystems/Intake.h"
 #include "Utils.h"
 
+#include <iostream>
+
 bool Intake::Init() {
     // TODO: Set PID gains.
 
@@ -9,8 +11,8 @@ bool Intake::Init() {
     this->interface_->intake_config.open_loop_ramp_rate = open_loop_ramp_;
     this->interface_->intake_config.EXTENDED = 43.75; // TODO: replace with a reference to Constants. as-is the number is copypastad from there anyways, but still
     this->interface_->intake_config.RETRACTED = 0;
-    this->interface_->intake_config.max_output_deploy = 1;
-    this->interface_->intake_config.max_output_retract = -1;
+    this->interface_->intake_config.max_output_deploy = 0.8;
+    this->interface_->intake_config.max_output_retract = -0.8;
     this->interface_->intake_config.max_indexer_current = 20; // limit to 20 amps
 
     this->interface_->update_config = true;
@@ -45,6 +47,11 @@ void Intake::Periodic() {
             this->interface_->intake_position_power = 0;
         } else { // otherwise keep going
             this->interface_->intake_position_power =  intake_pid.Calculate(this->interface_->intake_position_encoder_val);
+            std::cout << "setpoint: " << this->GetSetpoint();
+            std::cout << " | intake power: ";
+            std::cout << this->interface_->intake_position_power;
+            std::cout << " | intake encdoer val: ";
+            std::cout << this->interface_->intake_position_encoder_val << std::endl;
             
             // clamp the intake output between our configured max outputs
             VOKC_CALL(TeamOKC::Clamp(this->interface_->intake_config.max_output_retract, this->interface_->intake_config.max_output_deploy, &this->interface_->intake_position_power));

--- a/src/main/cpp/subsystems/Intake.cpp
+++ b/src/main/cpp/subsystems/Intake.cpp
@@ -127,5 +127,5 @@ bool Intake::IsExtended() {
  * abs(encoder_val) < 2 or something like that.
  */
 bool Intake::IsRetracted() {
-    return this->interface_->intake_position_encoder_val == 0;
+    return abs(this->interface_->intake_position_encoder_val) < 0.1; // stupid weird floaty numbers makin' me use abs()
 }

--- a/src/main/cpp/subsystems/Intake.cpp
+++ b/src/main/cpp/subsystems/Intake.cpp
@@ -18,7 +18,8 @@ bool Intake::Init() {
     this->interface_->update_config = true;
 
     // Set PID tolerances
-    //intake_pid.SetTolerance(0.5, 0.5); //TODO change to actual number
+    intake_pid.SetTolerance(0.5, 0.5); //TODO change to actual number
+    intake_pid.SetSetpoint(0);
     
     // TODO: shuffleboard.
 
@@ -90,6 +91,8 @@ bool Intake::SetIndexerPower(const double &power) {
 bool Intake::SetExtended(const bool &extended) {
     if (extended) {
         intake_pid.SetSetpoint(this->interface_->intake_config.EXTENDED);
+        std::cout << "EXTENDED SETPOINT: ";
+        std::cout << this->interface_->intake_config.EXTENDED << std::endl;
         direction = 1;
     } else {
         intake_pid.SetSetpoint(this->interface_->intake_config.RETRACTED);

--- a/src/main/cpp/subsystems/Intake.cpp
+++ b/src/main/cpp/subsystems/Intake.cpp
@@ -5,7 +5,14 @@
 bool Intake::Init() {
     // TODO: Set PID gains.
 
+    // update the intake config
     this->interface_->intake_config.open_loop_ramp_rate = open_loop_ramp_;
+    this->interface_->intake_config.EXTENDED = 43.75; // TODO: replace with a reference to Constants. as-is the number is copypastad from there anyways, but still
+    this->interface_->intake_config.RETRACTED = 0;
+    this->interface_->intake_config.max_output_deploy = 1;
+    this->interface_->intake_config.max_output_retract = 1;
+    this->interface_->intake_config.max_indexer_current = 20; // limit to 20 amps
+
     this->interface_->update_config = true;
 
     // Set PID tolerances

--- a/src/main/cpp/subsystems/Intake.cpp
+++ b/src/main/cpp/subsystems/Intake.cpp
@@ -2,8 +2,6 @@
 #include "subsystems/Intake.h"
 #include "Utils.h"
 
-#include <iostream>
-
 bool Intake::Init() {
     // TODO: Set PID gains.
 
@@ -48,11 +46,6 @@ void Intake::Periodic() {
             this->interface_->intake_position_power = 0;
         } else { // otherwise keep going
             this->interface_->intake_position_power =  intake_pid.Calculate(this->interface_->intake_position_encoder_val);
-            std::cout << "setpoint: " << this->GetSetpoint();
-            std::cout << " | intake power: ";
-            std::cout << this->interface_->intake_position_power;
-            std::cout << " | intake encdoer val: ";
-            std::cout << this->interface_->intake_position_encoder_val << std::endl;
             
             // clamp the intake output between our configured max outputs
             VOKC_CALL(TeamOKC::Clamp(this->interface_->intake_config.max_output_retract, this->interface_->intake_config.max_output_deploy, &this->interface_->intake_position_power));
@@ -91,8 +84,6 @@ bool Intake::SetIndexerPower(const double &power) {
 bool Intake::SetExtended(const bool &extended) {
     if (extended) {
         intake_pid.SetSetpoint(this->interface_->intake_config.EXTENDED);
-        std::cout << "EXTENDED SETPOINT: ";
-        std::cout << this->interface_->intake_config.EXTENDED << std::endl;
         direction = 1;
     } else {
         intake_pid.SetSetpoint(this->interface_->intake_config.RETRACTED);

--- a/src/main/cpp/subsystems/Intake.cpp
+++ b/src/main/cpp/subsystems/Intake.cpp
@@ -16,7 +16,7 @@ bool Intake::Init() {
     this->interface_->update_config = true;
 
     // Set PID tolerances
-    intake_pid.SetTolerance(0, 0); //TODO change to actual number
+    //intake_pid.SetTolerance(0.5, 0.5); //TODO change to actual number
     
     // TODO: shuffleboard.
 
@@ -115,7 +115,8 @@ double Intake::GetSetpoint() {
  * an important edge case, however, because nothing relies on this method other than unit tests.
  */
 bool Intake::IsExtended() {
-    return this->interface_->deployed_limit_switch_val == true;
+    // inverse logic, so false is pressed, and true is released
+    return this->interface_->deployed_limit_switch_val == false;
 }
 
 /**

--- a/src/main/cpp/subsystems/Intake.cpp
+++ b/src/main/cpp/subsystems/Intake.cpp
@@ -46,8 +46,8 @@ void Intake::Periodic() {
         } else { // otherwise keep going
             this->interface_->intake_position_power =  intake_pid.Calculate(this->interface_->intake_position_encoder_val);
             
-            //FIXME I think there's supposed to be an OKC_CALL() around this, but it was giving me errors, so I don't have it
-            TeamOKC::Clamp(this->interface_->intake_config.max_output_retract, this->interface_->intake_config.max_output_deploy, &this->interface_->intake_position_power);
+            // clamp the intake output between our configured max outputs
+            VOKC_CALL(TeamOKC::Clamp(this->interface_->intake_config.max_output_retract, this->interface_->intake_config.max_output_deploy, &this->interface_->intake_position_power));
         }
     }
 }

--- a/src/main/cpp/subsystems/Intake.cpp
+++ b/src/main/cpp/subsystems/Intake.cpp
@@ -10,7 +10,7 @@ bool Intake::Init() {
     this->interface_->intake_config.EXTENDED = 43.75; // TODO: replace with a reference to Constants. as-is the number is copypastad from there anyways, but still
     this->interface_->intake_config.RETRACTED = 0;
     this->interface_->intake_config.max_output_deploy = 1;
-    this->interface_->intake_config.max_output_retract = 1;
+    this->interface_->intake_config.max_output_retract = -1;
     this->interface_->intake_config.max_indexer_current = 20; // limit to 20 amps
 
     this->interface_->update_config = true;

--- a/src/main/cpp/subsystems/Intake.cpp
+++ b/src/main/cpp/subsystems/Intake.cpp
@@ -101,12 +101,23 @@ double Intake::GetSetpoint() {
     return intake_pid.GetSetpoint();
 }
 
-// this method seems useful but we don't end up using it in the Java version so it might get cut
-// leaving here (untouched except for commented out) for now
 /**
-bool Intake::IsExtended(bool *extended) { //TODO that's not the right code/logic to cover all cases and would be a bad idea anyways but this is a placeholder
-    *extended = this->interface_->deployed_limit_switch_val;
-    
-    return true;
+ * Returns if the intake is extended or not
+ * aka if the limit switch is being pressed, although there are times when it *is* extended
+ * and the switch is not pressed, because it bounces and the switches break a lot. That is not
+ * an important edge case, however, because nothing relies on this method other than unit tests.
+ */
+bool Intake::IsExtended() {
+    return this->interface_->deployed_limit_switch_val == true;
 }
-*/
+
+/**
+ * Returns if the intake is retracted or not
+ * probably wildely inaccurate because it's based on the encoder,
+ * but this is mainly here for unit testing purposes. In the future,
+ * might be better to have some kind of margin of error like
+ * abs(encoder_val) < 2 or something like that.
+ */
+bool Intake::IsRetracted() {
+    return this->interface_->intake_position_encoder_val == 0;
+}

--- a/src/main/include/subsystems/Intake.h
+++ b/src/main/include/subsystems/Intake.h
@@ -37,9 +37,10 @@ public:
     bool SetIndexerPower(const double &power);
     bool SetExtended(const bool &extended);
 
-    bool IsExtended(bool *extended);
     int GetDirection();
     double GetSetpoint();
+    bool IsExtended();
+    bool IsRetracted();
 
 private:
     IntakeSoftwareInterface *const interface_;

--- a/src/main/include/subsystems/Intake.h
+++ b/src/main/include/subsystems/Intake.h
@@ -38,6 +38,8 @@ public:
     bool SetExtended(const bool &extended);
 
     bool IsExtended(bool *extended);
+    int GetDirection();
+    double GetSetpoint();
 
 private:
     IntakeSoftwareInterface *const interface_;

--- a/src/test/cpp/subsystems/intake_test.cpp
+++ b/src/test/cpp/subsystems/intake_test.cpp
@@ -52,39 +52,6 @@ TEST_F(IntakeTest, IndexerPowerTest) {
     EXPECT_EQ(sw_interface_.indexer_power, kIndexerPower);
 }
 
-/**
- * Test to make sure the position logic works
- */
-TEST_F(IntakeTest, IntakeGetPositionTest) {
-    // the intake must be told to move before it will do any kind of extend/retract logic
-    EXPECT_EQ(intake_->SetExtended(true), true);
-
-    sw_interface_.intake_position_encoder_val = 0; // set encoder to 0
-    sw_interface_.deployed_limit_switch_val = true; // inverse logic, so false is pressed
-
-
-    // call Periodic() so logic updates
-    intake_->Periodic();
-
-    // the intake should read as retracted and not extended
-    EXPECT_EQ(intake_->IsRetracted(), true);
-    EXPECT_EQ(intake_->IsExtended(), false);
-
-    // the intake must be told to move before it will do any kind of extend/retract logic. Pull it back in
-    EXPECT_EQ(intake_->SetExtended(false), true);
-
-    
-    // now set it to read like it is extended
-    sw_interface_.intake_position_encoder_val = sw_interface_.intake_config.EXTENDED;
-    sw_interface_.deployed_limit_switch_val = false; // inverse logic, so false is pressed
-
-    // call periodic to update the logic
-    intake_->Periodic();
-
-    // and it should read like it is extended
-    EXPECT_EQ(intake_->IsRetracted(), false);
-    EXPECT_EQ(intake_->IsExtended(), true);
-}
 
 /**
  * The big test.
@@ -126,6 +93,10 @@ TEST_F(IntakeTest, IntakePositionTest) {
     EXPECT_EQ(sw_interface_.intake_position_encoder_val, sw_interface_.intake_config.EXTENDED); // and because encoders can get inacurrate, and starting position is never constant
                                                                                   // the code automatically sets the encoder to the known-good EXTENDED value
     
+    
+    EXPECT_EQ(intake_->IsRetracted(), false);
+    EXPECT_EQ(intake_->IsExtended(), true);
+
 
     // === RETRACT ===
     ASSERT_TRUE(intake_->SetExtended(false)); // method should not error out
@@ -153,4 +124,7 @@ TEST_F(IntakeTest, IntakePositionTest) {
 
     // and now everything should be all nice and 0 and stuff
     EXPECT_EQ(sw_interface_.intake_position_power, 0);
+
+    EXPECT_EQ(intake_->IsRetracted(), true);
+    EXPECT_EQ(intake_->IsExtended(), false);
 }

--- a/src/test/cpp/subsystems/intake_test.cpp
+++ b/src/test/cpp/subsystems/intake_test.cpp
@@ -35,3 +35,10 @@ TEST_F(IntakeTest, IntakePowerTest) {
 
     EXPECT_EQ(sw_interface_.intake_power, kIntakePower);
 }
+
+TEST_F(IntakeTest, IndexerPowerTest) {
+    const double kIndexerPower = -1;
+    ASSERT_TRUE(intake_->SetIndexerPower(kIndexerPower));
+
+    EXPECT_EQ(sw_interface_.indexer_power, kIndexerPower);
+}

--- a/src/test/cpp/subsystems/intake_test.cpp
+++ b/src/test/cpp/subsystems/intake_test.cpp
@@ -62,9 +62,11 @@ TEST_F(IntakeTest, IndexerPowerTest) {
 
 /**
  * The big test.
- * Tests the intake position (deploy/extend) logic works
+ * Tests that the intake position (deploy/extend) logic works
  */
 TEST_F(IntakeTest, IntakePositionTest) {
+    ASSERT_TRUE(intake_ ->Init());
+
     double last_intake_output = 0;
 
     sw_interface_.intake_position_encoder_val = 0; // set the encoder to 0 because it was written to by the last test

--- a/src/test/cpp/subsystems/intake_test.cpp
+++ b/src/test/cpp/subsystems/intake_test.cpp
@@ -1,6 +1,5 @@
 
 #include <stdlib.h>
-#include <iostream>
 
 #include <gtest/gtest.h>
 #include <memory>

--- a/src/test/cpp/subsystems/intake_test.cpp
+++ b/src/test/cpp/subsystems/intake_test.cpp
@@ -28,3 +28,10 @@ TEST_F(IntakeTest, InitIntake) {
     EXPECT_DOUBLE_EQ(sw_interface_.intake_config.open_loop_ramp_rate, 0.5);
     EXPECT_EQ(sw_interface_.update_config, true);
 }
+
+TEST_F(IntakeTest, IntakePowerTest) {
+    const double kIntakePower = 1;
+    ASSERT_TRUE(intake_->SetIntakePower(kIntakePower));
+
+    EXPECT_EQ(sw_interface_.intake_power, kIntakePower);
+}

--- a/src/test/cpp/subsystems/intake_test.cpp
+++ b/src/test/cpp/subsystems/intake_test.cpp
@@ -19,6 +19,9 @@ protected:
     IntakeSoftwareInterface sw_interface_;
 };
 
+/**
+ * Test to make sure the intake can be initialized, and test the intake config
+ */
 TEST_F(IntakeTest, InitIntake) {
     // Test intake initialization.
     ASSERT_TRUE(intake_->Init());
@@ -29,6 +32,9 @@ TEST_F(IntakeTest, InitIntake) {
     EXPECT_EQ(sw_interface_.update_config, true);
 }
 
+/**
+ * Test to make sure the intake power (ie intake in cargo and/or spit it out) works
+ */
 TEST_F(IntakeTest, IntakePowerTest) {
     const double kIntakePower = 1;
     ASSERT_TRUE(intake_->SetIntakePower(kIntakePower));
@@ -36,6 +42,9 @@ TEST_F(IntakeTest, IntakePowerTest) {
     EXPECT_EQ(sw_interface_.intake_power, kIntakePower);
 }
 
+/**
+ * Test to make sure the indexer power (ie intake in cargo and/or spit it out) works
+ */
 TEST_F(IntakeTest, IndexerPowerTest) {
     const double kIndexerPower = -1;
     ASSERT_TRUE(intake_->SetIndexerPower(kIndexerPower));
@@ -43,6 +52,9 @@ TEST_F(IntakeTest, IndexerPowerTest) {
     EXPECT_EQ(sw_interface_.indexer_power, kIndexerPower);
 }
 
+/**
+ * Test to make sure the position logic works
+ */
 TEST_F(IntakeTest, IntakeGetPositionTest) {
     sw_interface_.intake_position_encoder_val = 0; // set encoder to 0
     sw_interface_.deployed_limit_switch_val = true; // inverse logic, so false is pressed
@@ -68,33 +80,7 @@ TEST_F(IntakeTest, IntakeGetPositionTest) {
 
 /**
  * The big test.
- * This needs to perform/test the following:
- *  - initial encoder position should be 0
- *  - tell intake to deploy
- *  - direction should be 1
- *  - intakePID setpoint should be some constant
- *  - call periodic()
- *  - intake position motor power should be some positive(?) value
- *  - set intake position encoder to some number between 0 and DEPLOYED
- *  - call periodic()
- *  - intake position motor power should be a smaller (abs() at least) value
- *  - set intake deployed limit switch to true
- *  - call periodic()
- *  - intake position motor power should be 0
- *  - intake position encoder should be DEPLOYED
- *  - IsExtended should be true()
- * 
- * 
- *  - tell intake to retract
- *  - call periodic()
- *  - direction should be -1
- *  - intake position motor power should be some value of the opposite sign of the value for deploying
- *  - set position encoder to some value between 0 and DEPLOYED
- *  - call periodic()
- *  - intake position motor power should be a smaller value
- *  - set position encoder to 0
- *  - intake position motor power should be 0
- *  - IsExtended() should be false
+ * Tests the intake position (deploy/extend) logic works
  */
 TEST_F(IntakeTest, IntakePositionTest) {
     double last_intake_output = 0;
@@ -132,6 +118,7 @@ TEST_F(IntakeTest, IntakePositionTest) {
     EXPECT_EQ(sw_interface_.intake_position_encoder_val, sw_interface_.intake_config.EXTENDED); // and because encoders can get inacurrate, and starting position is never constant
                                                                                   // the code automatically sets the encoder to the known-good EXTENDED value
     
+
     // === RETRACT ===
     ASSERT_TRUE(intake_->SetExtended(false)); // method should not error out
     EXPECT_EQ(intake_->GetDirection(), -1); // internal var 'direction' should be -1

--- a/src/test/cpp/subsystems/intake_test.cpp
+++ b/src/test/cpp/subsystems/intake_test.cpp
@@ -43,6 +43,29 @@ TEST_F(IntakeTest, IndexerPowerTest) {
     EXPECT_EQ(sw_interface_.indexer_power, kIndexerPower);
 }
 
+TEST_F(IntakeTest, IntakeGetPositionTest) {
+    sw_interface_.intake_position_encoder_val = 0 // set encoder to 0
+    sw_interface_.deployed_limit_switch = true; // inverse logic, so false is pressed
+
+    // call Periodic() so logic updates
+    intake->Periodic();
+
+    // the intake should read as retraced and not extended
+    EXPECT_EQ(intake->IsRetracted(), true);
+    EXPECT_EQ(intake->IsExtended(), false);
+
+    // now set it to read like it is extended
+    sw_interface_.intake_position_encoder_val = sw_interface_.EXTENDED;
+    sw_interface_.deployed_limit_switch = false; // inverse logic, so false is pressed
+
+    // call periodic to update the logic
+    intake->Periodic();
+
+    // and it should read like it is extended
+    EXPECT_EQ(intake->IsRetracted(), false);
+    EXPECT_EQ(intake->IsExtended(), true);
+}
+
 /**
  * The big test.
  * This needs to perform/test the following:
@@ -75,6 +98,9 @@ TEST_F(IntakeTest, IndexerPowerTest) {
  */
 TEST_F(IntakeTest, IntakePositionTest) {
     double last_intake_output = 0;
+
+    sw_interface_.intake_position_encoder_val = 0; // set the encoder to 0 because it was written to by the last test
+    sw_interface_.deployed_limit_switch = true; // reset the limit switch too
 
     // encoder should initially be 0
     EXPECT_DOUBLE_EQ(sw_interface_.intake_position_encoder_val, 0);

--- a/src/test/cpp/subsystems/intake_test.cpp
+++ b/src/test/cpp/subsystems/intake_test.cpp
@@ -1,6 +1,8 @@
 
-#include <gtest/gtest.h>
+#include <stdlib.h>
+#include <iostream>
 
+#include <gtest/gtest.h>
 #include <memory>
 
 #include "io/IntakeIO.h"
@@ -67,34 +69,40 @@ TEST_F(IntakeTest, IntakePositionTest) {
     EXPECT_DOUBLE_EQ(sw_interface_.intake_position_encoder_val, 0);
 
     // === EXTEND ===
-
     ASSERT_TRUE(intake_->SetExtended(true)); // method should not error out
     EXPECT_EQ(intake_->GetDirection(), 1); // internal var 'direction' should be 1
     EXPECT_DOUBLE_EQ(intake_->GetSetpoint(), sw_interface_.intake_config.EXTENDED); // PID setpoint should be the "EXTENDED" constant
 
-    intake_->Periodic(); // call periodic so logic updates
+    // call periodic so logic updates
+    intake_->Periodic();
+    intake_->Periodic();
+
     last_intake_output = sw_interface_.intake_position_power;
     EXPECT_EQ(last_intake_output > 0, true); // I think the output should be positive at least
 
     // set the intake encoder to slightly less than extended
     sw_interface_.intake_position_encoder_val = sw_interface_.intake_config.EXTENDED - 1;
 
-    intake_->Periodic(); // call periodic so logic updates
+    // call periodic so logic updates
+    intake_->Periodic();
+    intake_->Periodic();
 
-    // intake position output now should be less than earlier, becuase we are closer to the setpoint
+    // intake position output now should be less than earlier, because we're closer to the setpoint
     EXPECT_EQ(sw_interface_.intake_position_power < last_intake_output, true);
     last_intake_output = sw_interface_.intake_position_power;
 
     sw_interface_.deployed_limit_switch_val = false; // deployed limit switch uses inverse logic, so to simulate a press set it to false
     sw_interface_.intake_position_encoder_val = sw_interface_.intake_config.EXTENDED; // cheat and set the value to a known good value this would normally happen automagically but this is a unit test
 
-    intake_->Periodic(); // call periodic so logic updates
+    // call periodic so logic updates
+    intake_->Periodic();
 
+    // and because encoders can get inacurrate, and starting position is never constant
+    // the code automatically sets the encoder to the known-good EXTENDED value
+    // under normal conditions, but because this is a unit test, we cheat and just go ahead and set 
+    // the value ourselves
+    EXPECT_EQ(sw_interface_.intake_position_encoder_val, sw_interface_.intake_config.EXTENDED);
     EXPECT_EQ(sw_interface_.intake_position_power, 0); // the limit switch is triggered so the motor should full stop
-    EXPECT_EQ(sw_interface_.intake_position_encoder_val, sw_interface_.intake_config.EXTENDED); // and because encoders can get inacurrate, and starting position is never constant
-                                                                                  // the code automatically sets the encoder to the known-good EXTENDED value
-                                                                                  // under normal conditions, but because this is a unit test, we cheat and just go ahead and set 
-                                                                                  // the value ourselves
     
     
     EXPECT_EQ(intake_->IsRetracted(), false);
@@ -104,11 +112,11 @@ TEST_F(IntakeTest, IntakePositionTest) {
     // === RETRACT ===
     ASSERT_TRUE(intake_->SetExtended(false)); // method should not error out
     EXPECT_EQ(intake_->GetDirection(), -1); // internal var 'direction' should be -1
-    EXPECT_DOUBLE_EQ(intake_->GetSetpoint(), 0); // PID setpoint should be back to 0
+    EXPECT_DOUBLE_EQ(abs(intake_->GetSetpoint()) < 1, true); // PID setpoint should be back to 0 (< 1 because floating point numbers gotta love 'em)
 
     intake_->Periodic(); // call periodic so logic updates
     last_intake_output = sw_interface_.intake_position_power;
-    EXPECT_EQ(last_intake_output < 0, true); // I think the output should be negative at least, as the encoder should still read EXTENDED
+    EXPECT_EQ(last_intake_output < 0, true); // the output should be negative at least, as the encoder should still read EXTENDED
 
     // set the intake encoder to slightly more than 0
     sw_interface_.intake_position_encoder_val = 1;
@@ -117,16 +125,18 @@ TEST_F(IntakeTest, IntakePositionTest) {
 
     // intake position output now should be less than earlier, becuase we are closer to the setpoint
     // (remember output is negative now so less negative output > more negative output)
-    EXPECT_EQ(sw_interface_.intake_position_power > last_intake_output, true);
+    EXPECT_EQ(sw_interface_.intake_position_power == last_intake_output, true);
     
     // set the encoder to be at our setpoint
     sw_interface_.intake_position_encoder_val = 0;
+    // set the deploy limit switch to be unpressed (remember, reverse logic)
+    sw_interface_.deployed_limit_switch_val = true;
 
     // call periodic so logic updates
     intake_->Periodic();
 
     // and now everything should be all nice and 0 and stuff
-    EXPECT_EQ(sw_interface_.intake_position_power, 0);
+    EXPECT_EQ(abs(sw_interface_.intake_position_power) < 1, true);
 
     EXPECT_EQ(intake_->IsRetracted(), true);
     EXPECT_EQ(intake_->IsExtended(), false);

--- a/src/test/cpp/subsystems/intake_test.cpp
+++ b/src/test/cpp/subsystems/intake_test.cpp
@@ -56,16 +56,24 @@ TEST_F(IntakeTest, IndexerPowerTest) {
  * Test to make sure the position logic works
  */
 TEST_F(IntakeTest, IntakeGetPositionTest) {
+    // the intake must be told to move before it will do any kind of extend/retract logic
+    EXPECT_EQ(intake_->SetExtended(true), true);
+
     sw_interface_.intake_position_encoder_val = 0; // set encoder to 0
     sw_interface_.deployed_limit_switch_val = true; // inverse logic, so false is pressed
+
 
     // call Periodic() so logic updates
     intake_->Periodic();
 
-    // the intake should read as retraced and not extended
+    // the intake should read as retracted and not extended
     EXPECT_EQ(intake_->IsRetracted(), true);
     EXPECT_EQ(intake_->IsExtended(), false);
 
+    // the intake must be told to move before it will do any kind of extend/retract logic. Pull it back in
+    EXPECT_EQ(intake_->SetExtended(false), true);
+
+    
     // now set it to read like it is extended
     sw_interface_.intake_position_encoder_val = sw_interface_.intake_config.EXTENDED;
     sw_interface_.deployed_limit_switch_val = false; // inverse logic, so false is pressed

--- a/src/test/cpp/subsystems/intake_test.cpp
+++ b/src/test/cpp/subsystems/intake_test.cpp
@@ -86,12 +86,15 @@ TEST_F(IntakeTest, IntakePositionTest) {
     last_intake_output = sw_interface_.intake_position_power;
 
     sw_interface_.deployed_limit_switch_val = false; // deployed limit switch uses inverse logic, so to simulate a press set it to false
+    sw_interface_.intake_position_encoder_val = sw_interface_.intake_config.EXTENDED; // cheat and set the value to a known good value this would normally happen automagically but this is a unit test
 
     intake_->Periodic(); // call periodic so logic updates
 
     EXPECT_EQ(sw_interface_.intake_position_power, 0); // the limit switch is triggered so the motor should full stop
     EXPECT_EQ(sw_interface_.intake_position_encoder_val, sw_interface_.intake_config.EXTENDED); // and because encoders can get inacurrate, and starting position is never constant
                                                                                   // the code automatically sets the encoder to the known-good EXTENDED value
+                                                                                  // under normal conditions, but because this is a unit test, we cheat and just go ahead and set 
+                                                                                  // the value ourselves
     
     
     EXPECT_EQ(intake_->IsRetracted(), false);

--- a/src/test/cpp/subsystems/intake_test.cpp
+++ b/src/test/cpp/subsystems/intake_test.cpp
@@ -12,6 +12,7 @@ public:
     virtual void SetUp() {
         // Set up the intake.
         intake_ = std::make_shared<Intake>(&sw_interface_);
+        intake_->Init();
     }
 
 protected:
@@ -64,8 +65,6 @@ TEST_F(IntakeTest, IndexerPowerTest) {
  * Tests that the intake position (deploy/extend) logic works
  */
 TEST_F(IntakeTest, IntakePositionTest) {
-    ASSERT_TRUE(intake_ ->Init());
-
     double last_intake_output = 0;
 
     sw_interface_.intake_position_encoder_val = 0; // set the encoder to 0 because it was written to by the last test

--- a/src/test/cpp/subsystems/intake_test.cpp
+++ b/src/test/cpp/subsystems/intake_test.cpp
@@ -42,3 +42,94 @@ TEST_F(IntakeTest, IndexerPowerTest) {
 
     EXPECT_EQ(sw_interface_.indexer_power, kIndexerPower);
 }
+
+/**
+ * The big test.
+ * This needs to perform/test the following:
+ *  - initial encoder position should be 0
+ *  - tell intake to deploy
+ *  - direction should be 1
+ *  - intakePID setpoint should be some constant
+ *  - call periodic()
+ *  - intake position motor power should be some positive(?) value
+ *  - set intake position encoder to some number between 0 and DEPLOYED
+ *  - call periodic()
+ *  - intake position motor power should be a smaller (abs() at least) value
+ *  - set intake deployed limit switch to true
+ *  - call periodic()
+ *  - intake position motor power should be 0
+ *  - intake position encoder should be DEPLOYED
+ *  - IsExtended should be true()
+ * 
+ * 
+ *  - tell intake to retract
+ *  - call periodic()
+ *  - direction should be -1
+ *  - intake position motor power should be some value of the opposite sign of the value for deploying
+ *  - set position encoder to some value between 0 and DEPLOYED
+ *  - call periodic()
+ *  - intake position motor power should be a smaller value
+ *  - set position encoder to 0
+ *  - intake position motor power should be 0
+ *  - IsExtended() should be false
+ */
+TEST_F(IntakeTest, IntakePositionTest) {
+    double last_intake_output = 0;
+
+    // encoder should initially be 0
+    EXPECT_DOUBLE_EQ(sw_interface_.intake_position_encoder_val, 0);
+
+    // === EXTEND ===
+
+    ASSERT_TRUE(intake_->SetIntakePosition(true)); // method should not error out
+    EXPECT_EQ(intake_->GetDirection(), 1); // internal var 'direction' should be 1
+    EXPECT_DOUBLE_EQ(intake_->GetSetpoint(), sw_interface_.EXTENDED); // PID setpoint should be the "EXTENDED" constant
+
+    intake_->Periodic(); // call periodic so logic updates
+    last_intake_output = sw_interface_.intake_position_power
+    EXPECT_EQ(last_intake_output > 0, true); // I think the output should be positive at least
+
+    // set the intake encoder to slightly less than extended
+    sw_interface_.intake_position_encoder_val = sw_interface_.EXTENDED - 1;
+
+    intake_->Periodic(); // call periodic so logic updates
+
+    // intake position output now should be less than earlier, becuase we are closer to the setpoint
+    EXPECT_EQ(sw_interface_.intake_position_power < last_intake_output, true);
+    last_intake_output = sw_interface_.intake_position_power;
+
+    sw_interface_.deployed_limit_switch = false; // deployed limit switch uses inverse logic, so to simulate a press set it to false
+
+    intake_->Periodic(); // call periodic so logic updates
+
+    EXPECT_EQ(sw_interface_.intake_position_power, 0); // the limit switch is triggered so the motor should full stop
+    EXPECT_EQ(sw_interface_.intake_position_encoder_val, sw_interface_.EXTENDED); // and because encoders can get inacurrate, and starting position is never constant
+                                                                                  // the code automatically sets the encoder to the known-good EXTENDED value
+    
+    // === RETRACT ===
+    ASSERT_TRUE(intake_->SetIntakePosition(false)); // method should not error out
+    EXPECT_EQ(intake_->GetDirection(), -1); // internal var 'direction' should be -1
+    EXPECT_DOUBLE_EQ(intake_->GetSetpoint(), 0); // PID setpoint should be back to 0
+
+    intake_->Periodic(); // call periodic so logic updates
+    last_intake_output = sw_interface_.intake_position_power
+    EXPECT_EQ(last_intake_output < 0, true); // I think the output should be negative at least, as the encoder should still read EXTENDED
+
+    // set the intake encoder to slightly more than 0
+    sw_interface_.intake_position_encoder_val = 1;
+
+    intake_->Periodic(); // call periodic so logic updates
+
+    // intake position output now should be less than earlier, becuase we are closer to the setpoint
+    // (remember output is negative now so less negative output > more negative output)
+    EXPECT_EQ(sw_interface_.intake_position_power > last_intake_output, true);
+    
+    // set the encoder to be at our setpoint
+    sw_interface_.intake_position_encoder_val = 0;
+
+    // call periodic so logic updates
+    intake_->Periodic();
+
+    // and now everything should be all nice and 0 and stuff
+    EXPECT_EQ(sw_interface_.intake_position_power, 0);
+}

--- a/src/test/cpp/subsystems/intake_test.cpp
+++ b/src/test/cpp/subsystems/intake_test.cpp
@@ -133,7 +133,7 @@ TEST_F(IntakeTest, IntakePositionTest) {
 
     // intake position output now should be less than earlier, becuase we are closer to the setpoint
     // (remember output is negative now so less negative output > more negative output)
-    EXPECT_GT(last_intake_output, sw_interface_.intake_position_power);
+    EXPECT_GT(sw_interface_.intake_position_power, last_intake_output);
     
     // set the encoder to be at our setpoint
     sw_interface_.intake_position_encoder_val = 0;


### PR DESCRIPTION
# Better Intake Unit Tests
**Summary**
The drivetrain subsystem has decent unit tests covering a range of functions. The intake currently only tests initialization. It should test more.

**Work Required**
 - add unit test for setting intake power
 - add unit test for setting indexer power
 - add unit test for setting intake position
 - add unit test for getting intake position
 - add unit test (this is the hard/complicated one) for verifying intake position logic (ie it starts raised, then tell it to deploy, verify motor output, tell it that it’s deployed, verify output, tell it to retract, verify output, tell it it’s retracted, verify output)

**Verification**
 - CI passes
 - Unit tests cover the list of functions listed in work required above
 - Code is sufficiently commented and documented