### PR TITLE
#26: fixes the shuffleboard values to be global pointers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ import org.gradle.internal.os.OperatingSystem
 plugins {
     id "cpp"
     id "google-test-test-suite"
-    id "edu.wpi.first.GradleRIO" version "2023.1.1-beta-3"
+    id "edu.wpi.first.GradleRIO" version "2023.1.1-beta-7"
 }
 
 // Define my targets (RoboRIO) and artifacts (deployable files)

--- a/src/main/cpp/subsystems/Drivetrain.cpp
+++ b/src/main/cpp/subsystems/Drivetrain.cpp
@@ -231,9 +231,9 @@ bool Drivetrain::ResetEncoders() {
     interface_->reset_encoders = true;
 
     // Update encoder UI
-    DrivetrainUI::nt_left_ticks.SetDouble(0);
-    DrivetrainUI::nt_right_ticks.SetDouble(0);
-    DrivetrainUI::nt_total_ticks.SetDouble(0);
+    DrivetrainUI::nt_left_ticks->SetDouble(0);
+    DrivetrainUI::nt_right_ticks->SetDouble(0);
+    DrivetrainUI::nt_total_ticks->SetDouble(0);
 
     return true;
 }
@@ -329,17 +329,17 @@ bool Drivetrain::InitShuffleboard() {
     double turn_d = RobotParams::GetParam("drivetrain.turn_pid.Kp", 0);
 
     // Update dashboard.
-    DrivetrainUI::nt_dist_kp.SetDouble(dist_p);
-    DrivetrainUI::nt_dist_ki.SetDouble(dist_i);
-    DrivetrainUI::nt_dist_kd.SetDouble(dist_d);
+    DrivetrainUI::nt_dist_kp->SetDouble(dist_p);
+    DrivetrainUI::nt_dist_ki->SetDouble(dist_i);
+    DrivetrainUI::nt_dist_kd->SetDouble(dist_d);
 
-    DrivetrainUI::nt_heading_kp.SetDouble(heading_p);
-    DrivetrainUI::nt_heading_ki.SetDouble(heading_i);
-    DrivetrainUI::nt_heading_kd.SetDouble(heading_d);
+    DrivetrainUI::nt_heading_kp->SetDouble(heading_p);
+    DrivetrainUI::nt_heading_ki->SetDouble(heading_i);
+    DrivetrainUI::nt_heading_kd->SetDouble(heading_d);
 
-    DrivetrainUI::nt_turn_kp.SetDouble(turn_p);
-    DrivetrainUI::nt_turn_ki.SetDouble(turn_i);
-    DrivetrainUI::nt_turn_kd.SetDouble(turn_d);
+    DrivetrainUI::nt_turn_kp->SetDouble(turn_p);
+    DrivetrainUI::nt_turn_ki->SetDouble(turn_i);
+    DrivetrainUI::nt_turn_kd->SetDouble(turn_d);
 
     return true;
 }
@@ -352,23 +352,23 @@ bool Drivetrain::UpdateShuffleboard() {
         // Update encoder UI
         double encoder_tmp = 0.0;
         OKC_CALL(GetLeftEncoderAverage(&encoder_tmp));
-        DrivetrainUI::nt_left_ticks.SetDouble(encoder_tmp);
+        DrivetrainUI::nt_left_ticks->SetDouble(encoder_tmp);
         OKC_CALL(GetRightEncoderAverage(&encoder_tmp));
-        DrivetrainUI::nt_right_ticks.SetDouble(encoder_tmp);
+        DrivetrainUI::nt_right_ticks->SetDouble(encoder_tmp);
         OKC_CALL(GetEncoderAverage(&encoder_tmp));
-        DrivetrainUI::nt_total_ticks.SetDouble(encoder_tmp);
+        DrivetrainUI::nt_total_ticks->SetDouble(encoder_tmp);
 
         // Heading UI
         double heading_tmp = 0.0;
         OKC_CALL(GetHeading(&heading_tmp));
-        DrivetrainUI::nt_heading.SetDouble(heading_tmp);
+        DrivetrainUI::nt_heading->SetDouble(heading_tmp);
 
         // Distance UI
         double dist_err = dist_pid_.GetPositionError();
-        DrivetrainUI::nt_dist_error.SetDouble(dist_err);
+        DrivetrainUI::nt_dist_error->SetDouble(dist_err);
 
         // Update the PID Gains if write mode is true.
-        if (DrivetrainUI::nt_write_mode.GetBoolean(false)) {
+        if (DrivetrainUI::nt_write_mode->GetBoolean(false)) {
             // Get the current PID parameter values
             double dist_p =
                 RobotParams::GetParam("drivetrain.distance_pid.Kp", 0);
@@ -389,17 +389,17 @@ bool Drivetrain::UpdateShuffleboard() {
             double turn_d = RobotParams::GetParam("drivetrain.turn_pid.Kp", 0);
 
             // Get the values from shuffleboard.
-            dist_p = DrivetrainUI::nt_dist_kp.GetDouble(dist_p);
-            dist_i = DrivetrainUI::nt_dist_ki.GetDouble(dist_i);
-            dist_d = DrivetrainUI::nt_dist_kd.GetDouble(dist_d);
+            dist_p = DrivetrainUI::nt_dist_kp->GetDouble(dist_p);
+            dist_i = DrivetrainUI::nt_dist_ki->GetDouble(dist_i);
+            dist_d = DrivetrainUI::nt_dist_kd->GetDouble(dist_d);
 
-            heading_p = DrivetrainUI::nt_heading_kp.GetDouble(heading_p);
-            heading_i = DrivetrainUI::nt_heading_ki.GetDouble(heading_i);
-            heading_d = DrivetrainUI::nt_heading_kd.GetDouble(heading_d);
+            heading_p = DrivetrainUI::nt_heading_kp->GetDouble(heading_p);
+            heading_i = DrivetrainUI::nt_heading_ki->GetDouble(heading_i);
+            heading_d = DrivetrainUI::nt_heading_kd->GetDouble(heading_d);
 
-            turn_p = DrivetrainUI::nt_turn_kp.GetDouble(turn_p);
-            turn_i = DrivetrainUI::nt_turn_ki.GetDouble(turn_i);
-            turn_d = DrivetrainUI::nt_turn_kd.GetDouble(turn_d);
+            turn_p = DrivetrainUI::nt_turn_kp->GetDouble(turn_p);
+            turn_i = DrivetrainUI::nt_turn_ki->GetDouble(turn_i);
+            turn_d = DrivetrainUI::nt_turn_kd->GetDouble(turn_d);
 
             // Distance PID
             dist_pid_.SetPID(dist_p, dist_i, dist_d);
@@ -408,17 +408,17 @@ bool Drivetrain::UpdateShuffleboard() {
         }
 
         // Allow saving parameters in non-competition modes
-        if (DrivetrainUI::nt_save.GetBoolean(true)) {
+        if (DrivetrainUI::nt_save->GetBoolean(true)) {
             // Save the parameters.
             OKC_CALL(RobotParams::SaveParameters(RobotParams::param_file));
-            DrivetrainUI::nt_save.SetBoolean(false);
+            DrivetrainUI::nt_save->SetBoolean(false);
         }
     }
 
     // Resetting the Gyro needs to always be available.
-    if (DrivetrainUI::nt_reset_gyro.GetBoolean(false)) {
+    if (DrivetrainUI::nt_reset_gyro->GetBoolean(false)) {
         interface_->reset_gyro = true;
-        DrivetrainUI::nt_reset_gyro.SetBoolean(false);
+        DrivetrainUI::nt_reset_gyro->SetBoolean(false);
     }
 
     return true;

--- a/src/main/cpp/subsystems/Shooter.cpp
+++ b/src/main/cpp/subsystems/Shooter.cpp
@@ -79,7 +79,7 @@ bool Shooter::SetShooter(const double &rpm) {
     output_log_->Append(power);
 
     // Update shuffleboard setpoint.
-    ShooterUI::nt_setpoint.SetDouble(rpm);
+    ShooterUI::nt_setpoint->SetDouble(rpm);
 
     // Output power.
     interface_->shooter_power = power;
@@ -168,9 +168,9 @@ bool Shooter::InitShuffleboard() {
     double shoot_i = RobotParams::GetParam("shooter.shoot_pid.Ki", 0);
     double shoot_d = RobotParams::GetParam("shooter.shoot_pid.Kp", 0);
 
-    ShooterUI::nt_shoot_kp.SetDouble(shoot_p);
-    ShooterUI::nt_shoot_ki.SetDouble(shoot_i);
-    ShooterUI::nt_shoot_kd.SetDouble(shoot_d);
+    ShooterUI::nt_shoot_kp->SetDouble(shoot_p);
+    ShooterUI::nt_shoot_ki->SetDouble(shoot_i);
+    ShooterUI::nt_shoot_kd->SetDouble(shoot_d);
 
     return true;
 }
@@ -182,26 +182,26 @@ bool Shooter::UpdateShuffleboard() {
     if (!is_competition) {
         // For some reason we don't update the shooter displays if it's a
         // competition
-        ShooterUI::nt_rpm.SetDouble(interface_->shooter_rpm);
+        ShooterUI::nt_rpm->SetDouble(interface_->shooter_rpm);
 
         bool at_setpoint = false;
         OKC_CALL(IsAtShooterSetpoint(&at_setpoint));
-        ShooterUI::nt_shooter_good.SetBoolean(at_setpoint);
+        ShooterUI::nt_shooter_good->SetBoolean(at_setpoint);
 
-        ShooterUI::nt_vel_err.SetDouble(interface_->velocity_error);
-        ShooterUI::nt_ticks.SetDouble(interface_->ticks);
-        ShooterUI::nt_output.SetDouble(interface_->shooter_output_pct);
+        ShooterUI::nt_vel_err->SetDouble(interface_->velocity_error);
+        ShooterUI::nt_ticks->SetDouble(interface_->ticks);
+        ShooterUI::nt_output->SetDouble(interface_->shooter_output_pct);
 
-        if (ShooterUI::nt_write_mode.GetBoolean(false)) {
+        if (ShooterUI::nt_write_mode->GetBoolean(false)) {
             // Get the current PID parameter values.
             double shoot_p = RobotParams::GetParam("shooter.shoot_pid.Kp", 0);
             double shoot_i = RobotParams::GetParam("shooter.shoot_pid.Ki", 0);
             double shoot_d = RobotParams::GetParam("shooter.shoot_pid.Kp", 0);
 
             // Get the values from shuffleboard.
-            shoot_p = ShooterUI::nt_shoot_kp.GetDouble(shoot_p);
-            shoot_i = ShooterUI::nt_shoot_ki.GetDouble(shoot_i);
-            shoot_d = ShooterUI::nt_shoot_kd.GetDouble(shoot_d);
+            shoot_p = ShooterUI::nt_shoot_kp->GetDouble(shoot_p);
+            shoot_i = ShooterUI::nt_shoot_ki->GetDouble(shoot_i);
+            shoot_d = ShooterUI::nt_shoot_kd->GetDouble(shoot_d);
 
             // Set the PID gains.
             shooter_pid_.SetPID(shoot_p, shoot_i, shoot_d);

--- a/src/main/cpp/ui/UserInterface.cpp
+++ b/src/main/cpp/ui/UserInterface.cpp
@@ -6,38 +6,47 @@ namespace DrivetrainUI {
 
     // Add all the defaults
     // Write mode
-    nt::GenericEntry &nt_write_mode =
+    nt::GenericEntry *const nt_write_mode =
         nt_tab.Add("Write Mode", false).GetEntry();
 
     // Encoder
-    nt::GenericEntry &nt_left_ticks = nt_tab.Add("left ticks", 0).GetEntry();
-    nt::GenericEntry &nt_right_ticks = nt_tab.Add("right ticks", 0).GetEntry();
-    nt::GenericEntry &nt_total_ticks = nt_tab.Add("total ticks", 0).GetEntry();
-    nt::GenericEntry &nt_dist_error =
+    nt::GenericEntry *const nt_left_ticks =
+        nt_tab.Add("left ticks", 0).GetEntry();
+    nt::GenericEntry *const nt_right_ticks =
+        nt_tab.Add("right ticks", 0).GetEntry();
+    nt::GenericEntry *const nt_total_ticks =
+        nt_tab.Add("total ticks", 0).GetEntry();
+    nt::GenericEntry *const nt_dist_error =
         nt_tab.Add("distance error", 0).GetEntry();
 
     // Distance PID
-    nt::GenericEntry &nt_dist_kp = nt_tab.Add("Distance kP", 0).GetEntry();
-    nt::GenericEntry &nt_dist_ki = nt_tab.Add("Distance kI", 0).GetEntry();
-    nt::GenericEntry &nt_dist_kd = nt_tab.Add("Distance kD", 0).GetEntry();
+    nt::GenericEntry *const nt_dist_kp =
+        nt_tab.Add("Distance kP", 0).GetEntry();
+    nt::GenericEntry *const nt_dist_ki =
+        nt_tab.Add("Distance kI", 0).GetEntry();
+    nt::GenericEntry *const nt_dist_kd =
+        nt_tab.Add("Distance kD", 0).GetEntry();
 
     // Heading PID
-    nt::GenericEntry &nt_heading = nt_tab.Add("Heading", 0).GetEntry();
-    nt::GenericEntry &nt_heading_kp = nt_tab.Add("Heading kP", 0).GetEntry();
-    nt::GenericEntry &nt_heading_ki = nt_tab.Add("Heading kI", 0).GetEntry();
-    nt::GenericEntry &nt_heading_kd = nt_tab.Add("Heading kD", 0).GetEntry();
+    nt::GenericEntry *const nt_heading = nt_tab.Add("Heading", 0).GetEntry();
+    nt::GenericEntry *const nt_heading_kp =
+        nt_tab.Add("Heading kP", 0).GetEntry();
+    nt::GenericEntry *const nt_heading_ki =
+        nt_tab.Add("Heading kI", 0).GetEntry();
+    nt::GenericEntry *const nt_heading_kd =
+        nt_tab.Add("Heading kD", 0).GetEntry();
 
     // Turn PID
-    nt::GenericEntry &nt_turn_kp = nt_tab.Add("Turn kP", 0).GetEntry();
-    nt::GenericEntry &nt_turn_ki = nt_tab.Add("Turn kI", 0).GetEntry();
-    nt::GenericEntry &nt_turn_kd = nt_tab.Add("Turn kD", 0).GetEntry();
+    nt::GenericEntry *const nt_turn_kp = nt_tab.Add("Turn kP", 0).GetEntry();
+    nt::GenericEntry *const nt_turn_ki = nt_tab.Add("Turn kI", 0).GetEntry();
+    nt::GenericEntry *const nt_turn_kd = nt_tab.Add("Turn kD", 0).GetEntry();
 
     // Gyro
-    nt::GenericEntry &nt_reset_gyro =
+    nt::GenericEntry *const nt_reset_gyro =
         nt_tab.Add("Reset Gyro", false).GetEntry();
 
     // Save parameters button
-    nt::GenericEntry &nt_save = nt_tab.Add("Save", false).GetEntry();
+    nt::GenericEntry *const nt_save = nt_tab.Add("Save", false).GetEntry();
 } // namespace DrivetrainUI
 
 namespace ShooterUI {
@@ -45,32 +54,41 @@ namespace ShooterUI {
     frc::ShuffleboardTab &nt_tab = frc::Shuffleboard::GetTab("Shooter");
 
     // Write mode
-    nt::GenericEntry &nt_write_mode =
+    nt::GenericEntry *const nt_write_mode =
         nt_tab.Add("Write Mode", false).GetEntry();
 
     // sensors
-    nt::GenericEntry &nt_ticks = nt_tab.Add("Shooter Ticks", 0).GetEntry();
-    nt::GenericEntry &nt_rpm = nt_tab.Add("Shooter RPM", 0).GetEntry();
-    nt::GenericEntry &nt_output = nt_tab.Add("Shooter Output", 0).GetEntry();
-    nt::GenericEntry &nt_setpoint = nt_tab.Add("Setpoint", 0).GetEntry();
-    nt::GenericEntry &nt_vel_err = nt_tab.Add("Velocity Error", 0).GetEntry();
-    nt::GenericEntry &nt_has_ball = nt_tab.Add("Has Ball?", false).GetEntry();
+    nt::GenericEntry *const nt_ticks =
+        nt_tab.Add("Shooter Ticks", 0).GetEntry();
+    nt::GenericEntry *const nt_rpm = nt_tab.Add("Shooter RPM", 0).GetEntry();
+    nt::GenericEntry *const nt_output =
+        nt_tab.Add("Shooter Output", 0).GetEntry();
+    nt::GenericEntry *const nt_setpoint = nt_tab.Add("Setpoint", 0).GetEntry();
+    nt::GenericEntry *const nt_vel_err =
+        nt_tab.Add("Velocity Error", 0).GetEntry();
+    nt::GenericEntry *const nt_has_ball =
+        nt_tab.Add("Has Ball?", false).GetEntry();
 
     // PID
-    nt::GenericEntry &nt_shoot_kp = nt_tab.Add("Shooter kP", 0).GetEntry();
-    nt::GenericEntry &nt_shoot_ki = nt_tab.Add("Shooter kI", 0).GetEntry();
-    nt::GenericEntry &nt_shoot_kd = nt_tab.Add("Shooter kD", 0).GetEntry();
+    nt::GenericEntry *const nt_shoot_kp =
+        nt_tab.Add("Shooter kP", 0).GetEntry();
+    nt::GenericEntry *const nt_shoot_ki =
+        nt_tab.Add("Shooter kI", 0).GetEntry();
+    nt::GenericEntry *const nt_shoot_kd =
+        nt_tab.Add("Shooter kD", 0).GetEntry();
 
     // Status
-    nt::GenericEntry &nt_shooter_good =
+    nt::GenericEntry *const nt_shooter_good =
         nt_tab.Add("Shooter Good", false).GetEntry();
 
     // Presets
-    nt::GenericEntry &nt_normal_shot =
+    nt::GenericEntry *const nt_normal_shot =
         nt_tab.Add("Normal Shot Preset", 0).GetEntry();
-    nt::GenericEntry &nt_against_hub =
+    nt::GenericEntry *const nt_against_hub =
         nt_tab.Add("Against Hub Preset", 0).GetEntry();
-    nt::GenericEntry &nt_low_goal = nt_tab.Add("Low Goal Preset", 0).GetEntry();
-    nt::GenericEntry &nt_far_shot = nt_tab.Add("Far Shot Preset", 0).GetEntry();
+    nt::GenericEntry *const nt_low_goal =
+        nt_tab.Add("Low Goal Preset", 0).GetEntry();
+    nt::GenericEntry *const nt_far_shot =
+        nt_tab.Add("Far Shot Preset", 0).GetEntry();
 
 } // namespace ShooterUI

--- a/src/main/include/ui/UserInterface.h
+++ b/src/main/include/ui/UserInterface.h
@@ -13,62 +13,62 @@ namespace DrivetrainUI {
 
     // Add all the defaults
     // Write mode
-    extern nt::GenericEntry &nt_write_mode;
+    extern nt::GenericEntry *const nt_write_mode;
 
     // Encoder
-    extern nt::GenericEntry &nt_left_ticks;
-    extern nt::GenericEntry &nt_right_ticks;
-    extern nt::GenericEntry &nt_total_ticks;
-    extern nt::GenericEntry &nt_dist_error;
+    extern nt::GenericEntry *const nt_left_ticks;
+    extern nt::GenericEntry *const nt_right_ticks;
+    extern nt::GenericEntry *const nt_total_ticks;
+    extern nt::GenericEntry *const nt_dist_error;
 
     // Distance PID
-    extern nt::GenericEntry &nt_dist_kp;
-    extern nt::GenericEntry &nt_dist_ki;
-    extern nt::GenericEntry &nt_dist_kd;
+    extern nt::GenericEntry *const nt_dist_kp;
+    extern nt::GenericEntry *const nt_dist_ki;
+    extern nt::GenericEntry *const nt_dist_kd;
 
     // Heading PID
-    extern nt::GenericEntry &nt_heading;
-    extern nt::GenericEntry &nt_heading_kp;
-    extern nt::GenericEntry &nt_heading_ki;
-    extern nt::GenericEntry &nt_heading_kd;
+    extern nt::GenericEntry *const nt_heading;
+    extern nt::GenericEntry *const nt_heading_kp;
+    extern nt::GenericEntry *const nt_heading_ki;
+    extern nt::GenericEntry *const nt_heading_kd;
 
     // Turn PID
-    extern nt::GenericEntry &nt_turn_kp;
-    extern nt::GenericEntry &nt_turn_ki;
-    extern nt::GenericEntry &nt_turn_kd;
+    extern nt::GenericEntry *const nt_turn_kp;
+    extern nt::GenericEntry *const nt_turn_ki;
+    extern nt::GenericEntry *const nt_turn_kd;
 
     // Gyro
-    extern nt::GenericEntry &nt_reset_gyro;
+    extern nt::GenericEntry *const nt_reset_gyro;
 
     // Save drivetrain parameters
-    extern nt::GenericEntry &nt_save;
+    extern nt::GenericEntry *const nt_save;
 } // namespace DrivetrainUI
 
 namespace ShooterUI {
     extern frc::ShuffleboardTab &nt_tab;
 
     // Write mode
-    extern nt::GenericEntry &nt_write_mode;
+    extern nt::GenericEntry *const nt_write_mode;
 
     // sensors
-    extern nt::GenericEntry &nt_ticks;
-    extern nt::GenericEntry &nt_rpm;
-    extern nt::GenericEntry &nt_output;
-    extern nt::GenericEntry &nt_setpoint;
-    extern nt::GenericEntry &nt_vel_err;
-    extern nt::GenericEntry &nt_has_ball;
+    extern nt::GenericEntry *const nt_ticks;
+    extern nt::GenericEntry *const nt_rpm;
+    extern nt::GenericEntry *const nt_output;
+    extern nt::GenericEntry *const nt_setpoint;
+    extern nt::GenericEntry *const nt_vel_err;
+    extern nt::GenericEntry *const nt_has_ball;
 
     // PID
-    extern nt::GenericEntry &nt_shoot_kp;
-    extern nt::GenericEntry &nt_shoot_ki;
-    extern nt::GenericEntry &nt_shoot_kd;
+    extern nt::GenericEntry *const nt_shoot_kp;
+    extern nt::GenericEntry *const nt_shoot_ki;
+    extern nt::GenericEntry *const nt_shoot_kd;
 
     // Status
-    extern nt::GenericEntry &nt_shooter_good;
+    extern nt::GenericEntry *const nt_shooter_good;
 
     // Presets
-    extern nt::GenericEntry &nt_normal_shot;
-    extern nt::GenericEntry &nt_against_hub;
-    extern nt::GenericEntry &nt_low_goal;
-    extern nt::GenericEntry &nt_far_shot;
+    extern nt::GenericEntry *const nt_normal_shot;
+    extern nt::GenericEntry *const nt_against_hub;
+    extern nt::GenericEntry *const nt_low_goal;
+    extern nt::GenericEntry *const nt_far_shot;
 } // namespace ShooterUI


### PR DESCRIPTION
**Changes**
- Shuffleboard widgets are global pointers now rather than references.
- Null pointer checking needs to be added, but let's do this as part of the "rethinking how we do shuffleboard" ticket

